### PR TITLE
fix: tanstack-query 버전업 및 useSuspenseQuery 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@supabase/supabase-js": "^2.57.2",
         "@suspensive/react": "^3.7.0",
         "@tailwindcss/vite": "^4.1.12",
-        "@tanstack/react-query": "^4.41.0",
+        "@tanstack/react-query": "^5.90.2",
         "@toss/react": "^1.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1794,9 +1794,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.41.0.tgz",
-      "integrity": "sha512-193R4Jp9hjvlij6LryxrB5Mpbffd2L9PeWh3KlIy/hJV4SkBOfiQZ+jc5qAZLDCrdbkA5FjGj+UoDYw6TcNnyA==",
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1804,30 +1804,19 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.41.0.tgz",
-      "integrity": "sha512-4/euCZAv8zeaB5P/nQiySzB0JHM3tiraU9KjSvSlJAX7oIE9uPDZlHCkDg/bHYNXewzvsg0FtOMq0VUq8XMMOQ==",
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "4.41.0",
-        "use-sync-external-store": "^1.2.0"
+        "@tanstack/query-core": "5.90.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tinyhttp/accepts": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@supabase/supabase-js": "^2.57.2",
     "@suspensive/react": "^3.7.0",
     "@tailwindcss/vite": "^4.1.12",
-    "@tanstack/react-query": "^4.41.0",
+    "@tanstack/react-query": "^5.90.2",
     "@toss/react": "^1.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/hooks/useTmdbQuery.ts
+++ b/src/hooks/useTmdbQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useSuspenseQuery, type UseSuspenseQueryResult } from '@tanstack/react-query';
 import { TMDB_BASE_URL, TMDB_TOKEN } from '@/constants/tmdb';
 
 export function useTmdbQuery<T>(
@@ -6,15 +6,15 @@ export function useTmdbQuery<T>(
   endpoint: string,
   params: Record<string, string | number | boolean> = {},
   staleTime: number = 1000 * 60,
-): UseQueryResult<T> {
+): UseSuspenseQueryResult<T, Error> {
   const searchParams = new URLSearchParams({
     language: 'ko-KR',
-    ...Object.fromEntries(Object.entries(params).map(([key, value]) => [key, String(value)])),
+    ...Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)])),
   });
 
   const url = `${TMDB_BASE_URL}${endpoint}?${searchParams}`;
 
-  return useQuery<T>({
+  return useSuspenseQuery<T, Error>({
     queryKey: key,
     queryFn: async () => {
       const res = await fetch(url, {
@@ -27,7 +27,5 @@ export function useTmdbQuery<T>(
       return res.json();
     },
     staleTime,
-    cacheTime: 0,
-    suspense: true,
   });
 }


### PR DESCRIPTION
<!-- PR 제목 예시:
[missionX] X단계 미션 구현 - 000/0팀
-->

## 구현 사항
- tanstack query 버전업 및 useSuspenseQuery 적용

## 어려웠던 점
- 기존 에러사항으로 tanstack query 내 suspense 최신버전 사용 불가능으로 다운그레이드하여 수정했던 부분을  최신버전의 useSuspenseQuery 를 적용하여 구현
